### PR TITLE
FSDP support and paper-accurate fixes for UltraMemv2

### DIFF
--- a/fuse_ops/fused_index.py
+++ b/fuse_ops/fused_index.py
@@ -302,50 +302,41 @@ class FusedEinsumTopk(torch.autograd.Function):
 
 class FusedLookup(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, indices, weight, scores, padding_idx, vocab_size, per_layer_vocab_size, shift, group_size=1, has_padding_idx=True):
+    def forward(ctx, indices, weight_bf16, main_grad, scores, padding_idx, vocab_size, per_layer_vocab_size, shift, group_size=1, has_padding_idx=True):
+        # weight_bf16: bf16 view of the value table (cast at call site; same tensor if already bf16)
+        # main_grad:   fp32 gradient accumulation buffer owned by the optimizer
         ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift = vocab_size, per_layer_vocab_size, shift
         ctx.padding_idx = padding_idx
         ctx.has_padding_idx = has_padding_idx
         if group_size == 0:
             group_size = 1
         ctx.group_size = group_size
-        if weight.dtype == torch.float32:
-            new_weight = weight.param_bf16
-        else:
-            new_weight = weight
-        ctx.save_for_backward(indices, weight, scores)
+        ctx.save_for_backward(indices, weight_bf16, main_grad, scores)
         import fused_lookup
-        output = fused_lookup.forward(indices.contiguous(), new_weight.contiguous(), scores.contiguous(), vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx)
+        output = fused_lookup.forward(indices.contiguous(), weight_bf16.contiguous(), scores.contiguous(), vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx)
         return output
 
     @staticmethod
     def backward(ctx, grad_output):
-        indices, weight, scores = ctx.saved_tensors
+        indices, weight_bf16, main_grad, scores = ctx.saved_tensors
         import fused_lookup
-        if weight.dtype == torch.float32:
-            new_weight = weight.param_bf16
-        else:
-            new_weight = weight
-        if hasattr(weight, "main_grad"):
-            score_grad = fused_lookup.backward(indices.contiguous(), new_weight.contiguous(), scores.contiguous(), grad_output.contiguous(), weight.main_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
-            weight_grad = None
-        else:
-            weight_grad = torch.zeros_like(weight, dtype=torch.float32)
-            score_grad = fused_lookup.backward(indices.contiguous(), new_weight.contiguous(), scores.contiguous(), grad_output.contiguous(), weight_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
-        return None, weight_grad, score_grad, None,None,None, None, None, None
+        # main_grad storage is shared with the original Parameter's main_grad buffer;
+        # the C++ kernel accumulates into it in-place.
+        score_grad = fused_lookup.backward(indices.contiguous(), weight_bf16.contiguous(), scores.contiguous(), grad_output.contiguous(), main_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
+        # inputs: indices, weight_bf16, main_grad, scores, padding_idx, vocab_size,
+        #         per_layer_vocab_size, shift, group_size, has_padding_idx
+        return None, None, None, score_grad, None, None, None, None, None, None
 
 
 class XperfGlu(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, indices, weight, p_input, vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx):
+    def forward(ctx, indices, weight_bf16, main_grad, p_input, vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx):
+        # weight_bf16: bf16 view of the value table (cast at call site; same tensor if already bf16)
+        # main_grad:   fp32 gradient accumulation buffer owned by the optimizer
         ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size = vocab_size, per_layer_vocab_size, shift, group_size
-        ctx.save_for_backward(indices, weight, p_input)
+        ctx.save_for_backward(indices, weight_bf16, main_grad, p_input)
         import fused_glu
-        if weight.dtype == torch.float32:
-            new_weight = weight.param_bf16
-        else:
-            new_weight = weight
-        output = fused_glu.forward(indices, new_weight, p_input, vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx)
+        output = fused_glu.forward(indices, weight_bf16, p_input, vocab_size, per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx)
         ctx.padding_idx = padding_idx
         ctx.has_padding_idx = has_padding_idx
         return output
@@ -353,16 +344,11 @@ class XperfGlu(torch.autograd.Function):
     @staticmethod
     def backward(ctx, output_grad):
         import fused_glu
-        indices, weight, p_input = ctx.saved_tensors
-        if weight.dtype == torch.float32:
-            new_weight = weight.param_bf16
-        else:
-            new_weight = weight
-        if hasattr(weight, "main_grad"):
-            p_input_grad = fused_glu.backward(indices, new_weight, p_input, output_grad.contiguous(), weight.main_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
-            weight_grad = None
-        else:
-            weight_grad = torch.zeros_like(weight, dtype=torch.float32)
-            p_input_grad = fused_glu.backward(indices, new_weight, p_input, output_grad.contiguous(), weight_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
-        return None, weight_grad, p_input_grad, None, None, None, None, None, None
+        indices, weight_bf16, main_grad, p_input = ctx.saved_tensors
+        # main_grad storage is shared with the original Parameter's main_grad buffer;
+        # the C++ kernel accumulates into it in-place.
+        p_input_grad = fused_glu.backward(indices, weight_bf16, p_input, output_grad.contiguous(), main_grad, ctx.vocab_size, ctx.per_layer_vocab_size, ctx.shift, ctx.group_size, ctx.padding_idx, ctx.has_padding_idx)
+        # inputs: indices, weight_bf16, main_grad, p_input, vocab_size,
+        #         per_layer_vocab_size, shift, group_size, padding_idx, has_padding_idx
+        return None, None, None, p_input_grad, None, None, None, None, None, None
 

--- a/fuse_ops/test_fused_lookup.py
+++ b/fuse_ops/test_fused_lookup.py
@@ -25,7 +25,9 @@ scores2.requires_grad=True
 vocab_size = weight1.shape[0] - 1
 per_layer_vocab_size = weight1.shape[0] - 1
 shift = 0
-out1 = FusedLookup.apply(indices, weight1, scores1.permute(2,0,1).contiguous(), 0, vocab_size, per_layer_vocab_size, shift, group_size, False)
+weight1_bf16 = weight1 if weight1.dtype == torch.bfloat16 else weight1.to(torch.bfloat16)
+main_grad1 = torch.zeros_like(weight1, dtype=torch.float32)
+out1 = FusedLookup.apply(indices, weight1_bf16, main_grad1, scores1.permute(2,0,1).contiguous(), 0, vocab_size, per_layer_vocab_size, shift, group_size, False)
 
 out_rand_like = torch.rand_like(out1)
 loss1=(out1 * out_rand_like).sum()
@@ -67,7 +69,7 @@ diff1=out1-out2
 print("weight1.grad", scores1.grad)
 print("weight2.grad", scores2.grad)
 print("diff1", diff1.max(), diff1.min())
-diff2=weight1.grad-weight2.grad
+diff2=main_grad1.to(weight2.grad.dtype)-weight2.grad
 print("diff2", diff2.max(), diff2.min())
 diff3=scores1.grad-scores2.grad
 print("diff3", diff3.max(), diff3.min())

--- a/fuse_ops/test_glu.py
+++ b/fuse_ops/test_glu.py
@@ -30,7 +30,9 @@ p_input2.requires_grad = True
 vocab_size = weight1.shape[0]
 per_layer_vocab_size = weight1.shape[0]
 shift = 0
-out1 = XperfGlu.apply(indices, weight1, p_input1, vocab_size, per_layer_vocab_size, shift, group_size, 0, False)
+weight1_bf16 = weight1 if weight1.dtype == torch.bfloat16 else weight1.to(torch.bfloat16)
+main_grad1 = torch.zeros_like(weight1, dtype=torch.float32)
+out1 = XperfGlu.apply(indices, weight1_bf16, main_grad1, p_input1, vocab_size, per_layer_vocab_size, shift, group_size, 0, False)
 # print("out1", out1)
 out_rand_like = torch.rand_like(out1)
 loss1=(out1 * out_rand_like).sum()
@@ -50,7 +52,7 @@ loss2.backward()
 
 diff1=out1-out2
 print("diff1", diff1.max(), diff1.min())
-diff2=weight1.grad-weight2.grad
+diff2=main_grad1.to(weight2.grad.dtype)-weight2.grad
 print("diff2", diff2.max(), diff2.min())
 diff3=p_input1.grad-p_input2.grad
 print("diff3", diff3.max(), diff3.min())

--- a/olmo/checkpoint.py
+++ b/olmo/checkpoint.py
@@ -96,6 +96,57 @@ log = logging.getLogger(__name__)
 MODEL_AND_OPTIM_FOLDER = "model_and_optim"
 
 
+def _partition_state_dict(
+    state_dict: Dict[str, Any], ignored_key: str
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Split state dict into FSDP-managed and ignored (vertical-parallel) parts by key substring."""
+    managed: Dict[str, Any] = {}
+    ignored: Dict[str, Any] = {}
+    for k, v in state_dict.items():
+        if ignored_key in k:
+            ignored[k] = v
+        else:
+            managed[k] = v
+    return managed, ignored
+
+
+def _extract_ignored_optim_state(optim, ignored_key: str) -> Dict[str, Any]:
+    """Extract optimizer state for ignored params directly from the optimizer.
+
+    This bypasses FSDP's optim_state_dict machinery, which only handles
+    FSDP-managed params correctly.  Each rank extracts its own local state
+    for the ignored (vertical-parallel) params.
+    """
+    result: Dict[str, Any] = {}
+    for group in optim.param_groups:
+        for name, param in zip(group["param_names"], group["params"]):
+            if ignored_key in name and param in optim.state:
+                result[name] = {
+                    k: v.cpu() if isinstance(v, torch.Tensor) else v
+                    for k, v in optim.state[param].items()
+                }
+    return result
+
+
+def _restore_ignored_optim_state(optim, saved_state: Dict[str, Any], ignored_key: str) -> None:
+    """Restore optimizer state for ignored (vertical-parallel) params."""
+    for group in optim.param_groups:
+        for name, param in zip(group["param_names"], group["params"]):
+            if ignored_key in name and name in saved_state:
+                optim.state[param] = {
+                    k: v.to(param.device) if isinstance(v, torch.Tensor) else v
+                    for k, v in saved_state[name].items()
+                }
+
+
+def _set_param_by_name(module: nn.Module, dotted_name: str, value: torch.Tensor) -> None:
+    """Set a parameter's data by its dotted name path (e.g. 'transformer.full_memory_layer.values_for_look_up')."""
+    parts = dotted_name.split(".")
+    for part in parts[:-1]:
+        module = getattr(module, part)
+    getattr(module, parts[-1]).data.copy_(value)
+
+
 def save_fsdp_model_and_optim_state(
     checkpoint_dir: PathOrStr,
     fsdp_model: FSDP,
@@ -637,6 +688,7 @@ class FullCheckpointer(Checkpointer):
     ) -> None:
         with self._temporary_wd(dir) as checkpoint_dir:
             if isinstance(dist_model, FSDP):
+                vertical_parallel = self.cfg.model.vertical_parallel
                 with FSDP.state_dict_type(
                     dist_model,
                     state_dict_type=StateDictType.FULL_STATE_DICT,
@@ -646,14 +698,35 @@ class FullCheckpointer(Checkpointer):
                     # We'll write the model and optimizer state dicts individually to reduce (CPU) memory consumption.
                     # First the model state.
                     model_state_dict = dist_model.state_dict()
-                    self._write_model_dict(
-                        model_state_dict, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
-                    )
+                    if vertical_parallel:
+                        # Vertical-parallel value tables are excluded from FSDP (ignored_states),
+                        # so each rank only has its local slice. Save FSDP-managed params on rank 0
+                        # (full), and ignored params per-rank to rank_{N}/model.pt.
+                        managed, ignored = _partition_state_dict(model_state_dict, "full_memory_layer")
+                        self._write_model_dict(
+                            managed, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
+                        )
+                        self._write_model_dict_mp(
+                            ignored, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
+                        )
+                    else:
+                        self._write_model_dict(
+                            model_state_dict, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
+                        )
 
                     # Then the optimizer state.
                     optim_state_dict = FSDP.optim_state_dict(dist_model, optim)
                     self._write_optim_dict(
                         optim_state_dict, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
+                    )
+
+                if vertical_parallel:
+                    # Save optimizer state for ignored (vertical-parallel) params per-rank.
+                    # Done outside the FSDP state_dict_type context since these params are
+                    # not managed by FSDP — we extract directly from the optimizer.
+                    ignored_optim = _extract_ignored_optim_state(optim, "full_memory_layer")
+                    self._write_optim_dict_mp(
+                        ignored_optim, checkpoint_dir, upload_to, save_overwrite=self.cfg.save_overwrite
                     )
             elif isinstance(dist_model, DDP):
                 vertical_parallel = self.cfg.model.vertical_parallel
@@ -778,6 +851,43 @@ class FullCheckpointer(Checkpointer):
                             torch.cuda.empty_cache()
                         barrier()
                     del optim_state_dict_to_load
+
+            # Restore ignored (vertical-parallel) params from per-rank checkpoint.
+            # These are saved separately because FSDP's FULL_STATE_DICT only gathers
+            # FSDP-managed params; ignored params need per-rank save/load.
+            vertical_parallel = self.cfg.model.vertical_parallel
+            if vertical_parallel:
+                vp_state = load_state_dict(
+                    load_path / Path(f"rank_{get_global_rank()}"),
+                    "model.pt",
+                    local_cache=local_cache,
+                    map_location="cpu",
+                )
+                unwrapped = dist_model._fsdp_wrapped_module
+                with torch.no_grad():
+                    for key, value in vp_state.items():
+                        _set_param_by_name(unwrapped, key, value)
+                del vp_state
+
+                # Verify no NaNs in restored ignored params.
+                if hasattr(unwrapped.transformer, "full_memory_layer"):
+                    for name, param in unwrapped.transformer.full_memory_layer.named_parameters():
+                        if torch.isnan(param).any():
+                            raise ValueError(
+                                f"full_memory_layer.{name} contains NaNs after restore, "
+                                "vertical-parallel checkpoint may be incomplete"
+                            )
+
+                if load_optimizer_state:
+                    vp_optim = load_state_dict(
+                        load_path / Path(f"rank_{get_global_rank()}"),
+                        "optim.pt",
+                        local_cache=local_cache,
+                        map_location="cpu",
+                    )
+                    _restore_ignored_optim_state(optim, vp_optim, "full_memory_layer")
+                    del vp_optim
+
         elif isinstance(dist_model, DDP):
             # Load model state.
             vertical_parallel = self.cfg.model.vertical_parallel

--- a/olmo/memory_plus_layer.py
+++ b/olmo/memory_plus_layer.py
@@ -165,7 +165,9 @@ class MemoryLayerPlus(torch.nn.Module):
         if True:
             from fuse_ops.fused_index import FusedLookup
             best_scores = best_scores.squeeze(dim=-1)
-            output = FusedLookup.apply(best_indice.to(torch.int32), full_memory_layer.values_for_look_up, best_scores, 0, self.value_num, self.value_num, 0, 1, False)
+            val_w = full_memory_layer.values_for_look_up
+            val_w_bf16 = val_w if val_w.dtype == torch.bfloat16 else val_w.to(torch.bfloat16)
+            output = FusedLookup.apply(best_indice.to(torch.int32), val_w_bf16, val_w.main_grad, best_scores, 0, self.value_num, self.value_num, 0, 1, False)
         else:
             real_indice = best_indice_shuffled % self.value_num
             group_indice = best_indice_shuffled // self.value_num

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -1424,7 +1424,7 @@ class OLMo(nn.Module):
         else:
             return device
 
-    def reset_parameters(self, distributed_strategy):
+    def reset_parameters(self, distributed_strategy, skip_mem_layers: bool = False):
         log.info("Initializing model parameters...")
         # Top-level embeddings / linear layers.
 
@@ -1491,10 +1491,11 @@ class OLMo(nn.Module):
             for block_group in self.transformer.block_groups:
                 block_group.reset_parameters()
         
-        for mem_layer in self.transformer.mem_blocks:
-            mem_layer.reset_parameters(distributed_strategy)
-        if (self.config.mem_type == 'ultramem_v2' or self.config.mem_type =='memory_plus') and hasattr(self.transformer, "full_memory_layer"):
-            self.transformer.full_memory_layer.reset_parameters(distributed_strategy)
+        if not skip_mem_layers:
+            for mem_layer in self.transformer.mem_blocks:
+                mem_layer.reset_parameters(distributed_strategy)
+            if (self.config.mem_type == 'ultramem_v2' or self.config.mem_type =='memory_plus') and hasattr(self.transformer, "full_memory_layer"):
+                self.transformer.full_memory_layer.reset_parameters(distributed_strategy)
 
     def get_alibi_attention_bias(self, seq_len: int, device: torch.device) -> torch.Tensor:
         if (alibi_bias := self.__cache.get("alibi_attention_bias")) is not None and alibi_bias.shape[
@@ -1671,7 +1672,14 @@ class OLMo(nn.Module):
                     )
                 if self.mem_insert_way == 'full':
                     if self.config.mem_type == 'ultramem_v2'or self.config.mem_type == 'memory_plus':
-                        mem_out = self.transformer.mem_blocks[block_idx](block.ffn_input_after_norm, self.transformer.full_memory_layer)
+                        if should_checkpoint_block(self.activation_checkpointing_strategy, block_idx):
+                            mem_out = self._activation_checkpoint_fn(
+                                self.transformer.mem_blocks[block_idx],
+                                block.ffn_input_after_norm,
+                                self.transformer.full_memory_layer,
+                            )
+                        else:
+                            mem_out = self.transformer.mem_blocks[block_idx](block.ffn_input_after_norm, self.transformer.full_memory_layer)
                     else:
                         mem_out = self.transformer.mem_blocks[block_idx](block.ffn_input_after_norm)
                     x = x + mem_out
@@ -1679,7 +1687,14 @@ class OLMo(nn.Module):
                     if block_idx in self.mem_insert_way:
                         mem_out_idx, mem_layer_idx = self.mem_insert_way[block_idx]
                         if self.config.mem_type == 'ultramem_v2' or self.config.mem_type == 'memory_plus':
-                            mem_out = self.transformer.mem_blocks[mem_layer_idx](block.ffn_input_after_norm, self.transformer.full_memory_layer)
+                            if should_checkpoint_block(self.activation_checkpointing_strategy, block_idx):
+                                mem_out = self._activation_checkpoint_fn(
+                                    self.transformer.mem_blocks[mem_layer_idx],
+                                    block.ffn_input_after_norm,
+                                    self.transformer.full_memory_layer,
+                                )
+                            else:
+                                mem_out = self.transformer.mem_blocks[mem_layer_idx](block.ffn_input_after_norm, self.transformer.full_memory_layer)
                         else:
                             mem_out = self.transformer.mem_blocks[mem_layer_idx](block.ffn_input_after_norm)
                     if mem_out_idx == block_idx:

--- a/olmo/model.py
+++ b/olmo/model.py
@@ -1758,6 +1758,11 @@ class OLMo(nn.Module):
             def fsdp_wrap_fn(module, recurse: bool = True, nonwrapped_numel: int = 0):
                 del nonwrapped_numel
                 wrap = isinstance(module, OLMoBlock) or isinstance(module, UltraMemLayerV1) or isinstance(module, UltraMemLayerV2)
+                # full_memory_layer (has_value=True) is accessed directly by
+                # mem_blocks, not through its own forward(), so FSDP must not
+                # shard it independently.
+                if isinstance(module, (UltraMemLayerV1, UltraMemLayerV2)) and getattr(module, "has_value", False):
+                    wrap = False
                 if recurse:
                     return True
                 else:

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -1059,7 +1059,6 @@ class Trainer:
             for name, p in zip(group["param_names"], group["params"]):
                 if 'values_for_look_up' in name or 'pre_values_for_look_up' in name:
                     p.main_grad.zero_()
-                    p.param_bf16 = p.to(torch.bfloat16)
 
         # Move tensors to the right device.
         batch = move_to_device(batch, self.device)

--- a/olmo/train.py
+++ b/olmo/train.py
@@ -1034,10 +1034,14 @@ class Trainer:
             for hook in output_hooks:
                 hook.remove()
 
-        for name, param in self.model.named_parameters():
-            if param.grad is not None:
-                param.grad /= get_world_size()
-                dist.all_reduce(param.grad.data)
+        # Under FSDP, gradient reduce-scatter already happens during backward,
+        # so manual all-reduce would corrupt shards and can desync ranks.
+        # Only needed for DDP where no_sync() disables built-in gradient sync.
+        if self.cfg.distributed_strategy != DistributedStrategy.fsdp:
+            for name, param in self.model.named_parameters():
+                if param.grad is not None:
+                    param.grad /= get_world_size()
+                    dist.all_reduce(param.grad.data)
         return ce_batch_loss, z_batch_loss, lb_batch_loss, moe_z_batch_loss, expert_assignments
 
     def train_step(self, batch: Dict[str, Any], reduce_global_loss: bool = True) -> Dict[str, float]:

--- a/olmo/ultramem_layer.py
+++ b/olmo/ultramem_layer.py
@@ -252,7 +252,9 @@ class UltraMemLayerV1(torch.nn.Module):
                 best_scores = best_scores.permute(2,0,1).contiguous()
             else:
                 best_scores = best_scores.squeeze(dim=-1)
-            output = FusedLookup.apply(best_indice_shuffled.to(torch.int32), self.values_for_look_up, best_scores, 0, self.value_num, self.value_num, 0, self.value_expand_time, False)
+            val_w = self.values_for_look_up
+            val_w_bf16 = val_w if val_w.dtype == torch.bfloat16 else val_w.to(torch.bfloat16)
+            output = FusedLookup.apply(best_indice_shuffled.to(torch.int32), val_w_bf16, val_w.main_grad, best_scores, 0, self.value_num, self.value_num, 0, self.value_expand_time, False)
         else:
             real_indice = best_indice_shuffled % self.value_num
             group_indice = best_indice_shuffled // self.value_num

--- a/olmo/ultramem_layer_v2.py
+++ b/olmo/ultramem_layer_v2.py
@@ -648,12 +648,16 @@ class UltraMemLayerV2(torch.nn.Module):
             output_parallel = [p_inputs.view(-1), outputs_buffer, send_receive_count, send_receive_count]
             output = EmbeddingAll2AllSingle.apply(*output_parallel)
             output = output.view(memory_layer_parallel_size * max_entry_num, self.local_pre_vdim)
-            pre_score = XperfGlu.apply(total_indices, self.pre_values_for_look_up, output, all_value_num, value_num, offset, 1, 0, False)
+            pre_w = self.pre_values_for_look_up
+            pre_w_bf16 = pre_w if pre_w.dtype == torch.bfloat16 else pre_w.to(torch.bfloat16)
+            pre_score = XperfGlu.apply(total_indices, pre_w_bf16, pre_w.main_grad, output, all_value_num, value_num, offset, 1, 0, False)
             pre_score = AllReduceInMemGroup().apply(pre_score)
             if self.use_glu_act:
                 pre_score = F.gelu(pre_score)
             all_score = pre_score.squeeze(-1) * all_score
-        emb = FusedLookup.apply(total_indices, self.values_for_look_up, all_score, padding_idx, all_value_num, value_num, offset, self.fake_value_expand_time, has_padding_idx)
+        val_w = self.values_for_look_up
+        val_w_bf16 = val_w if val_w.dtype == torch.bfloat16 else val_w.to(torch.bfloat16)
+        emb = FusedLookup.apply(total_indices, val_w_bf16, val_w.main_grad, all_score, padding_idx, all_value_num, value_num, offset, self.fake_value_expand_time, has_padding_idx)
         entry_counts = [max_entry_num] * memory_layer_parallel_size
         emb_send_recv_count = [x * emb.shape[-1] for x in entry_counts]
         embedding_outputs_buffer = torch.empty(max_entry_num * emb.shape[-1] * memory_layer_parallel_size, dtype=emb.dtype, device=emb.device, requires_grad=False)
@@ -668,7 +672,9 @@ class UltraMemLayerV2(torch.nn.Module):
         if not USE_NPU:  # NPU does not support CUDA kernels
             from fuse_ops.fused_index import XperfGlu, FusedLookup
             if pre_input is not None:
-                pre_score = XperfGlu.apply(best_indice.to(torch.int32), self.pre_values_for_look_up, pre_input, all_value_num, value_num, offset, 1, 0, False)
+                pre_w = self.pre_values_for_look_up
+                pre_w_bf16 = pre_w if pre_w.dtype == torch.bfloat16 else pre_w.to(torch.bfloat16)
+                pre_score = XperfGlu.apply(best_indice.to(torch.int32), pre_w_bf16, pre_w.main_grad, pre_input, all_value_num, value_num, offset, 1, 0, False)
                 if self.use_glu_act:
                     pre_score = F.gelu(pre_score)
                 best_scores = pre_score.unsqueeze(-1) * best_scores
@@ -676,7 +682,9 @@ class UltraMemLayerV2(torch.nn.Module):
                 best_scores = best_scores.permute(2,0,1).contiguous()
             else:
                 best_scores = best_scores.squeeze(dim=-1)
-            output = FusedLookup.apply(best_indice.to(torch.int32), self.values_for_look_up, best_scores, 0, all_value_num, value_num, offset, self.fake_value_expand_time, False)
+            val_w = self.values_for_look_up
+            val_w_bf16 = val_w if val_w.dtype == torch.bfloat16 else val_w.to(torch.bfloat16)
+            output = FusedLookup.apply(best_indice.to(torch.int32), val_w_bf16, val_w.main_grad, best_scores, 0, all_value_num, value_num, offset, self.fake_value_expand_time, False)
         else:
             real_indice = ((best_indice % value_num) + offset) % all_value_num
 

--- a/olmo/ultramem_layer_v2.py
+++ b/olmo/ultramem_layer_v2.py
@@ -568,22 +568,25 @@ class UltraMemLayerV2(torch.nn.Module):
             score_list = score_list_mat.reshape(self.tucker_multihead, bs, head_num, -1)
             all_scores = score_list.sum(dim=0)
 
+        # Non-NPU (GPU) path selects the top-knn indices with a Triton gather,
+        # avoiding the O(knn^2) Cartesian index grid that OOMs at knn=256
+        # (paper Sec. 4.1).  NPU has no Triton kernel, so it keeps the explicit
+        # all_indices materialisation + gather.
         if not USE_NPU:
-            all_indices = (
-                indices1.view(bs, head_num, self.knn, 1).expand(bs, head_num, self.knn, self.knn) * n_keys +
-                indices2.view(bs, head_num, 1, self.knn).expand(bs, head_num, self.knn, self.knn)
-            ).view(bs, head_num, -1)
+            _, best_topk_idx = torch.topk(all_scores, k=self.knn, dim=2, largest=True, sorted=True)
+            best_scores = torch.stack([s.gather(2, best_topk_idx) for s in score_list], dim=-1).view(bs,-1,self.tucker_multihead)
+            from fuse_ops.fused_index import triton_gather_indices_2d
+            best_indices = triton_gather_indices_2d(
+                indices1.contiguous(), indices2.contiguous(), best_topk_idx.contiguous(), n_keys
+            ).view(bs, -1)
         else:
             all_indices = (
                 indices1.view(bs, head_num, self.knn, 1) * n_keys +
                 indices2.view(bs, head_num, 1, self.knn)
             ).view(bs, head_num, -1)
-
-        
-        scores, best_indices = torch.topk(all_scores, k=self.knn, dim=2, largest=True, sorted=True)
-
-        best_scores = torch.stack([s.gather(2, best_indices) for s in score_list], dim=-1).view(bs,-1,self.tucker_multihead)
-        best_indices = all_indices.gather(2, best_indices).view(bs,-1)
+            scores, best_indices = torch.topk(all_scores, k=self.knn, dim=2, largest=True, sorted=True)
+            best_scores = torch.stack([s.gather(2, best_indices) for s in score_list], dim=-1).view(bs,-1,self.tucker_multihead)
+            best_indices = all_indices.gather(2, best_indices).view(bs,-1)
 
         return best_scores, best_indices, balance_reg_loss_key
 

--- a/olmo/ultramem_layer_v2.py
+++ b/olmo/ultramem_layer_v2.py
@@ -161,6 +161,8 @@ class UltraMemLayerV2(torch.nn.Module):
         self.tucker_rank_penalty = tucker_rank_penalty
         self.v_proj_in_dim = v_proj_in_dim
         self.hidden_size = hidden_size
+        self.mem_layer_num = mem_layer_num
+        self.kinner = config.mlp_ratio
         self.key_balance_reg_coef = config.mem_key_balance_reg_coef
         self.mem_q_for_each_tucker_rank = config.mem_q_for_each_tucker_rank
         self.use_glu_act = config.mem_use_glu_act
@@ -210,8 +212,17 @@ class UltraMemLayerV2(torch.nn.Module):
 
     def reset_parameters(self, distributed_strategy):
         if self.has_value:
-            # value init
-            std_value1 = 0.02
+            # Paper Eq. 26 (Appendix A.3): set sigma_V so the memory layer's output
+            # variance at init equals that of a single FFN layer.
+            #   sigma_V = (0.2 * k_inner * h
+            #              / (k * n_head * (1+sigma_s^2) * d_prev * d_v * L))^(1/4)
+            # sigma_s^2 = variance of top-1 routing score after norm/temperature
+            # (paper App. A.2), measured empirically below.
+            sigma_s_sq = self._measure_sigma_s_squared()
+            numer = 0.2 * self.kinner * self.hidden_size
+            denom = (self.knn * self.head * (1.0 + sigma_s_sq)
+                     * max(self.pre_vdim, 1) * self.vdim * self.mem_layer_num)
+            std_value1 = (numer / denom) ** 0.25
             if self.vertical_parallel:
                 rank = get_memory_layer_parallel_rank()
                 start = rank * self.local_vdim
@@ -252,7 +263,13 @@ class UltraMemLayerV2(torch.nn.Module):
             nn.init.constant_(self.keys_norm.weight, val=1/self.kdim**0.4)
 
             nn.init.normal_(self.query_proj.weight, mean=0.0, std=1/(math.sqrt(self.kdim)))
-            nn.init.normal_(self.values_proj.weight, mean=0.0, std=1/(math.sqrt(self.v_proj_in_dim)))
+            # values_proj is the residual-stream projection — equivalent to OLMo's
+            # ff_out.  Paper App. A assumes it is 1/sqrt(2L)-scaled so the memory-layer
+            # output variance derived in Eq. 26 actually matches the FFN baseline.
+            # Without this, the memory residual dominates the residual stream by
+            # sqrt(2L) at init and Eq. 26's sigma_V is calibrated against a fictional
+            # baseline.
+            nn.init.normal_(self.values_proj.weight, mean=0.0, std=self._compute_values_proj_std())
 
             nn.init.normal_(self.keys, mean=0.0, std=1/(math.sqrt(self.kdim)))
             if self.pre_vdim > 0 :
@@ -290,7 +307,94 @@ class UltraMemLayerV2(torch.nn.Module):
         result = super().load_state_dict(*args, **kwargs)
         self.post_load_init()
         return result
-    
+
+    def _compute_values_proj_std(self):
+        """Init std for the residual-stream projection (`values_proj`).
+
+        Mirrors olmo/model.py reset_parameters logic for ff_out so the memory
+        residual at init matches the FFN residual.  Falls back to the legacy
+        1/sqrt(v_proj_in_dim) when init_fn is unset.
+        """
+        from olmo.config import InitFnType
+        init_fn = getattr(self.config, "init_fn", None)
+        n_layers = getattr(self.config, "n_layers", None)
+        init_std = getattr(self.config, "init_std", None)
+        if init_fn == InitFnType.full_megatron and n_layers and init_std:
+            return init_std / math.sqrt(2.0 * n_layers)
+        if init_fn == InitFnType.mitchell:
+            return 1.0 / math.sqrt(2 * self.v_proj_in_dim * (self.layer_id + 1))
+        if init_fn == InitFnType.normal and init_std:
+            return init_std
+        return 1.0 / math.sqrt(self.v_proj_in_dim)
+
+    @torch.no_grad()
+    def _measure_sigma_s_squared(self, n_samples: int = 2048) -> float:
+        """Empirical sigma_s^2 (paper App. A.2): variance of top-1 routing score
+        after norm/temperature, given current architectural choices.  Used by
+        Eq. 26.
+
+        Builds synthetic queries/keys matching the intended init distributions
+        (no FSDP, no GPU required).  Run once at init on the value-owning layer.
+        """
+        kdim = self.kdim
+        head = self.head
+        tucker_rank = self.tucker_rank
+        knn = min(self.knn, self.key_num)
+        # Match the actual norm-init formula used in reset_parameters above.
+        norm_init = 1.0 / kdim ** 0.4
+
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        # Post-layernorm input has unit variance.
+        x = torch.randn(n_samples, self.hidden_size, device=device, dtype=dtype)
+        qtr = tucker_rank if self.mem_q_for_each_tucker_rank else 1
+        q_w = torch.randn(self.hidden_size, kdim * 2 * qtr, device=device, dtype=dtype) / math.sqrt(kdim)
+        q = (x @ q_w).view(n_samples, 2, qtr, kdim)
+        # query_norm ~ layernorm with constant scale norm_init.
+        q = (q - q.mean(-1, keepdim=True)) / q.std(-1, unbiased=False, keepdim=True).clamp_min(1e-6) * norm_init
+
+        keys = torch.randn(head, 2, self.key_num, kdim, tucker_rank, device=device, dtype=dtype) / math.sqrt(kdim)
+        keys = (keys - keys.mean(-2, keepdim=True)) / keys.std(-2, unbiased=False, keepdim=True).clamp_min(1e-6) * norm_init
+
+        half = kdim // 2
+        s1_per_rank = []
+        s2_per_rank = []
+        for r in range(tucker_rank):
+            if self.mem_q_for_each_tucker_rank:
+                q1r = q[:, 0, r, :half]
+                q2r = q[:, 1, r, half:]
+            else:
+                q1r = q[:, 0, 0, :half]
+                q2r = q[:, 1, 0, half:]
+            s1_h = []
+            s2_h = []
+            for h_idx in range(head):
+                k1 = keys[h_idx, 0, :, :half, r]   # [key_num, half]
+                k2 = keys[h_idx, 1, :, half:, r]
+                s1_h.append(q1r @ k1.T)
+                s2_h.append(q2r @ k2.T)
+            s1_per_rank.append(torch.stack(s1_h, dim=1))  # [n, head, key_num]
+            s2_per_rank.append(torch.stack(s2_h, dim=1))
+        s1 = torch.stack(s1_per_rank, dim=-1)  # [n, head, key_num, tucker_rank]
+        s2 = torch.stack(s2_per_rank, dim=-1)
+
+        # tucker_core_uv is zero at init; the dominant-eigenvector projection
+        # collapses to picking rank-0.  Approximate by summing across ranks.
+        s1p = s1.sum(-1)  # [n, head, key_num]
+        s2p = s2.sum(-1)
+
+        s1_top, _ = s1p.topk(knn, dim=-1)
+        s2_top, _ = s2p.topk(knn, dim=-1)
+
+        # Bilinear via mean tucker_core entry (U(0,1) -> mean 0.5).
+        bilinear = (s1_top.unsqueeze(-1) * s2_top.unsqueeze(-2) * 0.5).reshape(n_samples, head, -1)
+        top_scores, _ = bilinear.topk(min(knn, bilinear.size(-1)), dim=-1)
+        # Normalize so mean top-1 ~ 1 (paper A.2 calibration target), then take var.
+        top1 = top_scores[..., 0]
+        mean = top1.mean().clamp_min(1e-6)
+        return float((top1 / mean).var().item())
+
     def _calc_tucker_1rank(self):
         tucker_core_sum = torch.stack(list(self.tucker_core), dim=0).sum(dim=0).to(torch.float32)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -150,10 +150,6 @@ def main(cfg: TrainConfig) -> None:
 
     olmo_model.set_activation_checkpointing(cfg.activation_checkpointing)
 
-    for name, param in olmo_model.named_parameters():
-        if param.requires_grad and ('values_for_look_up' in name or 'pre_values_for_look_up' in name):
-            param.main_grad = torch.zeros_like(param, device="cuda", dtype=torch.float32)
-
     if cfg.distributed_strategy == DistributedStrategy.ddp:
         log.info("Wrapping model with DDP...")
         assert cfg.ddp is not None, "DistributedStrategy ddp needs cfg.ddp to be set!"
@@ -229,7 +225,20 @@ def main(cfg: TrainConfig) -> None:
 
     # when param_init_fn is None, FSDP will call reset_parameters() automatically
     if param_init_fn is not None or cfg.distributed_strategy == DistributedStrategy.ddp:
-        olmo_model.reset_parameters(cfg.distributed_strategy)
+        if cfg.distributed_strategy == DistributedStrategy.fsdp:
+            # FSDP flattens and shards parameters, so we need to temporarily
+            # unshard them to initialize with the correct shapes.
+            with FSDP.summon_full_params(dist_model, writeback=True):
+                olmo_model.reset_parameters(cfg.distributed_strategy)
+        else:
+            olmo_model.reset_parameters(cfg.distributed_strategy)
+
+    # Allocate main_grad for value params after wrapping so that it uses the
+    # (potentially sharded) parameter shapes and doesn't bloat GPU memory
+    # before FSDP has a chance to shard.
+    for name, param in dist_model.named_parameters():
+        if param.requires_grad and ('values_for_look_up' in name or 'pre_values_for_look_up' in name):
+            param.main_grad = torch.zeros_like(param, device="cuda", dtype=torch.float32)
 
     log.info(f"Peak GPU Memory (MB) after {cfg.distributed_strategy}: {int(peak_gpu_memory() or 0)}")
     log.info("Model:")

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -207,6 +207,13 @@ def main(cfg: TrainConfig) -> None:
             hybrid_sharding_fsdp_kwargs["device_mesh"] = device_mesh
         # import ipdb; ipdb.set_trace()
 
+        # full_memory_layer is accessed directly by mem_blocks (not through
+        # FSDP's forward), so its params must not be sharded by FSDP.
+        ignored = []
+        if hasattr(olmo_model.transformer, "full_memory_layer"):
+            ignored = list(olmo_model.transformer.full_memory_layer.parameters()) + \
+                      list(olmo_model.transformer.full_memory_layer.buffers())
+
         dist_model = FSDP(
             olmo_model,
             sharding_strategy=cfg.fsdp.sharding_strategy,
@@ -216,7 +223,7 @@ def main(cfg: TrainConfig) -> None:
             limit_all_gathers=True,
             device_id=get_local_rank(),
             param_init_fn=param_init_fn,
-            ignored_states=[],
+            ignored_states=ignored,
             **hybrid_sharding_fsdp_kwargs,
         )
         # import ipdb; ipdb.set_trace()
@@ -228,14 +235,22 @@ def main(cfg: TrainConfig) -> None:
         if cfg.distributed_strategy == DistributedStrategy.fsdp:
             # FSDP flattens and shards parameters, so we need to temporarily
             # unshard them to initialize with the correct shapes.
+            # Mem layers contain collectives that conflict with FSDP's summon
+            # context — init transformer blocks inside summon, then mem layers outside.
             with FSDP.summon_full_params(dist_model, writeback=True):
-                olmo_model.reset_parameters(cfg.distributed_strategy)
+                olmo_model.reset_parameters(cfg.distributed_strategy, skip_mem_layers=True)
+            for mem_layer in olmo_model.transformer.mem_blocks:
+                mem_layer.reset_parameters(cfg.distributed_strategy)
+            if hasattr(olmo_model.transformer, "full_memory_layer"):
+                olmo_model.transformer.full_memory_layer.reset_parameters(cfg.distributed_strategy)
         else:
             olmo_model.reset_parameters(cfg.distributed_strategy)
 
     # Allocate main_grad for value params after wrapping so that it uses the
     # (potentially sharded) parameter shapes and doesn't bloat GPU memory
     # before FSDP has a chance to shard.
+    # Release fragmented memory from FSDP wrapping/init before allocating.
+    torch.cuda.empty_cache()
     for name, param in dist_model.named_parameters():
         if param.requires_grad and ('values_for_look_up' in name or 'pre_values_for_look_up' in name):
             param.main_grad = torch.zeros_like(param, device="cuda", dtype=torch.float32)

--- a/tests/test_fused_index_autograd.py
+++ b/tests/test_fused_index_autograd.py
@@ -1,0 +1,256 @@
+"""
+CPU-only autograd tests for the FusedLookup / XperfGlu refactor.
+
+These tests monkey-patch the C++ kernels (fused_lookup, fused_glu) with Python
+stubs so the autograd plumbing can be verified without a GPU.  They catch:
+
+  1. Signature / arity mismatches — PyTorch raises on wrong number of backward
+     return values.
+  2. save_for_backward round-trip — ctx.saved_tensors returns all four tensors
+     in the right order.
+  3. Storage identity of main_grad across save_for_backward — the sentinel test
+     proves that in-place writes to the saved tensor land in the original buffer,
+     which is the key property that the old param_bf16 pattern failed to provide.
+  4. Both fp32 (cast inserted) and bf16 (no cast) call-site paths.
+  5. XperfGlu symmetric treatment.
+"""
+import sys
+import types
+import torch
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub out the C++ extension modules before importing fused_index
+# ---------------------------------------------------------------------------
+
+def _make_lookup_stub():
+    """Stub for fused_lookup that returns zeros and accumulates a sentinel into
+    the weight-grad buffer so we can verify storage identity."""
+    mod = types.ModuleType("fused_lookup")
+
+    def forward(indices, weight, scores, vocab_size, per_layer_vocab_size,
+                shift, group_size, padding_idx, has_padding_idx):
+        bs = scores.shape[-1] if scores.dim() == 1 else scores.shape[0]
+        out_dim = weight.shape[-1] if weight.dim() >= 2 else 1
+        return torch.zeros(bs, out_dim, dtype=weight.dtype)
+
+    def backward(indices, weight, scores, grad_output, main_grad,
+                 vocab_size, per_layer_vocab_size, shift, group_size,
+                 padding_idx, has_padding_idx):
+        # Write a recognisable value into main_grad in-place so the storage
+        # identity test can detect it.
+        main_grad.fill_(42.0)
+        score_grad = torch.zeros_like(scores)
+        return score_grad
+
+    mod.forward = forward
+    mod.backward = backward
+    return mod
+
+
+def _make_glu_stub():
+    mod = types.ModuleType("fused_glu")
+
+    def forward(indices, weight, p_input, vocab_size, per_layer_vocab_size,
+                shift, group_size, padding_idx, has_padding_idx):
+        bs = p_input.shape[0]
+        return torch.zeros(bs, indices.shape[-1], dtype=weight.dtype)
+
+    def backward(indices, weight, p_input, output_grad, main_grad,
+                 vocab_size, per_layer_vocab_size, shift, group_size,
+                 padding_idx, has_padding_idx):
+        main_grad.fill_(42.0)
+        p_input_grad = torch.zeros_like(p_input)
+        return p_input_grad
+
+    mod.forward = forward
+    mod.backward = backward
+    return mod
+
+
+sys.modules.setdefault("fused_lookup", _make_lookup_stub())
+sys.modules.setdefault("fused_glu", _make_glu_stub())
+
+# Load fused_index.py directly via importlib to avoid triggering
+# fuse_ops/__init__.py which compiles CUDA extensions (requires a GPU).
+import importlib.util as _ilu
+import pathlib as _pl
+
+_spec = _ilu.spec_from_file_location(
+    "fuse_ops.fused_index",
+    _pl.Path(__file__).parent.parent / "fuse_ops" / "fused_index.py",
+)
+_mod = _ilu.module_from_spec(_spec)
+sys.modules["fuse_ops.fused_index"] = _mod
+_spec.loader.exec_module(_mod)
+
+FusedLookup = _mod.FusedLookup
+XperfGlu = _mod.XperfGlu
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_lookup_inputs(fp32_weight=False):
+    """Return (indices, weight_bf16, main_grad, scores, kwargs, weight_orig)."""
+    n_vocab, vdim = 64, 16
+    bs, knn = 4, 8
+    dtype = torch.float32 if fp32_weight else torch.bfloat16
+    weight_orig = torch.randn(n_vocab, vdim, dtype=dtype)
+    weight_bf16 = weight_orig if dtype == torch.bfloat16 else weight_orig.to(torch.bfloat16)
+    main_grad = torch.zeros(n_vocab, vdim, dtype=torch.float32)
+    indices = torch.randint(0, n_vocab, (bs, knn), dtype=torch.int32)
+    scores = torch.randn(bs, knn, requires_grad=True)
+    kwargs = dict(padding_idx=0, vocab_size=n_vocab, per_layer_vocab_size=n_vocab,
+                  shift=0, group_size=1, has_padding_idx=False)
+    return indices, weight_bf16, main_grad, scores, kwargs, weight_orig
+
+
+def _make_glu_inputs(fp32_weight=False):
+    """Return (indices, weight_bf16, main_grad, p_input, kwargs, weight_orig)."""
+    n_vocab, edim = 64, 16
+    bs, knn = 4, 8
+    dtype = torch.float32 if fp32_weight else torch.bfloat16
+    weight_orig = torch.randn(n_vocab, edim, dtype=dtype)
+    weight_bf16 = weight_orig if dtype == torch.bfloat16 else weight_orig.to(torch.bfloat16)
+    main_grad = torch.zeros(n_vocab, edim, dtype=torch.float32)
+    indices = torch.randint(0, n_vocab, (bs, knn), dtype=torch.int32)
+    p_input = torch.randn(bs, edim, requires_grad=True)
+    kwargs = dict(vocab_size=n_vocab, per_layer_vocab_size=n_vocab,
+                  shift=0, group_size=1, padding_idx=0, has_padding_idx=False)
+    return indices, weight_bf16, main_grad, p_input, kwargs, weight_orig
+
+
+# ---------------------------------------------------------------------------
+# FusedLookup tests
+# ---------------------------------------------------------------------------
+
+class TestFusedLookupSignature:
+    def test_forward_runs_bf16(self):
+        indices, weight_bf16, main_grad, scores, kw, _ = _make_lookup_inputs(fp32_weight=False)
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        assert out is not None
+
+    def test_forward_runs_fp32_weight(self):
+        """Cast happens at call site; FusedLookup always receives bf16."""
+        indices, weight_bf16, main_grad, scores, kw, weight_orig = _make_lookup_inputs(fp32_weight=True)
+        assert weight_bf16.dtype == torch.bfloat16
+        assert weight_bf16 is not weight_orig  # a new tensor was created by the cast
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        assert out is not None
+
+    def test_bf16_weight_no_copy(self):
+        """When weight is already bf16 the call site skips the cast."""
+        indices, weight_bf16, main_grad, scores, kw, weight_orig = _make_lookup_inputs(fp32_weight=False)
+        assert weight_bf16 is weight_orig  # same tensor, no allocation
+
+
+class TestFusedLookupBackward:
+    def test_backward_runs_without_error(self):
+        indices, weight_bf16, main_grad, scores, kw, _ = _make_lookup_inputs()
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        out.sum().backward()
+        assert scores.grad is not None
+
+    def test_backward_return_arity(self):
+        """PyTorch raises if the number of backward return values != number of inputs."""
+        indices, weight_bf16, main_grad, scores, kw, _ = _make_lookup_inputs()
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        # If arity were wrong this would raise RuntimeError
+        out.sum().backward()
+
+    def test_main_grad_storage_identity(self):
+        """
+        THE KEY TEST: the C++ stub writes 42 into main_grad in-place during
+        backward.  We verify the write landed in the ORIGINAL main_grad buffer
+        (same storage as what we passed to FusedLookup.apply), not a copy.
+        This is the property that the old param_bf16 pattern failed to provide
+        when ctx.saved_tensors returned a fresh Tensor after pack/unpack.
+        """
+        indices, weight_bf16, main_grad, scores, kw, _ = _make_lookup_inputs()
+        sentinel_value = 42.0
+        # Sanity: main_grad is all zeros before backward
+        assert main_grad.abs().max().item() == 0.0
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        out.sum().backward()
+        # The stub filled the saved main_grad tensor with 42; if storage is
+        # shared with our original main_grad buffer, we see it here.
+        assert main_grad.abs().max().item() == sentinel_value, (
+            "main_grad storage was NOT shared across save_for_backward — "
+            "the backward wrote into a copy, not the original buffer"
+        )
+
+    def test_weight_bf16_grad_is_none(self):
+        """FusedLookup returns None for weight_bf16 grad (gradient flows through main_grad)."""
+        indices, weight_bf16, main_grad, scores, kw, _ = _make_lookup_inputs()
+        weight_bf16 = weight_bf16.clone().requires_grad_(True)
+        out = FusedLookup.apply(indices, weight_bf16, main_grad, scores,
+                                kw["padding_idx"], kw["vocab_size"],
+                                kw["per_layer_vocab_size"], kw["shift"],
+                                kw["group_size"], kw["has_padding_idx"])
+        out.sum().backward()
+        assert weight_bf16.grad is None
+
+
+# ---------------------------------------------------------------------------
+# XperfGlu tests
+# ---------------------------------------------------------------------------
+
+class TestXperfGluSignature:
+    def test_forward_runs_bf16(self):
+        indices, weight_bf16, main_grad, p_input, kw, _ = _make_glu_inputs(fp32_weight=False)
+        out = XperfGlu.apply(indices, weight_bf16, main_grad, p_input,
+                             kw["vocab_size"], kw["per_layer_vocab_size"],
+                             kw["shift"], kw["group_size"],
+                             kw["padding_idx"], kw["has_padding_idx"])
+        assert out is not None
+
+    def test_forward_runs_fp32_weight(self):
+        indices, weight_bf16, main_grad, p_input, kw, weight_orig = _make_glu_inputs(fp32_weight=True)
+        assert weight_bf16.dtype == torch.bfloat16
+        assert weight_bf16 is not weight_orig
+        out = XperfGlu.apply(indices, weight_bf16, main_grad, p_input,
+                             kw["vocab_size"], kw["per_layer_vocab_size"],
+                             kw["shift"], kw["group_size"],
+                             kw["padding_idx"], kw["has_padding_idx"])
+        assert out is not None
+
+
+class TestXperfGluBackward:
+    def test_backward_runs_without_error(self):
+        indices, weight_bf16, main_grad, p_input, kw, _ = _make_glu_inputs()
+        out = XperfGlu.apply(indices, weight_bf16, main_grad, p_input,
+                             kw["vocab_size"], kw["per_layer_vocab_size"],
+                             kw["shift"], kw["group_size"],
+                             kw["padding_idx"], kw["has_padding_idx"])
+        out.sum().backward()
+        assert p_input.grad is not None
+
+    def test_main_grad_storage_identity(self):
+        """Same sentinel test as FusedLookup — verifies storage is preserved."""
+        indices, weight_bf16, main_grad, p_input, kw, _ = _make_glu_inputs()
+        assert main_grad.abs().max().item() == 0.0
+        out = XperfGlu.apply(indices, weight_bf16, main_grad, p_input,
+                             kw["vocab_size"], kw["per_layer_vocab_size"],
+                             kw["shift"], kw["group_size"],
+                             kw["padding_idx"], kw["has_padding_idx"])
+        out.sum().backward()
+        assert main_grad.abs().max().item() == 42.0, (
+            "XperfGlu main_grad storage was NOT shared across save_for_backward"
+        )

--- a/tests/test_ultramem_init_variance.py
+++ b/tests/test_ultramem_init_variance.py
@@ -1,0 +1,84 @@
+"""
+CPU-only sanity check for UltraMemV2 init scaling.
+
+Catches the two failure modes that broke prior runs even with Eq. 26 in place:
+  1. `_measure_sigma_s_squared` returning NaN / non-finite / wildly off scale.
+  2. `values_proj` not depth-scaled (would put memory residual ~sqrt(2L)x
+     larger than FFN residual at init, regardless of sigma_V correctness).
+
+These are config-level checks — no GPU and no FSDP needed.
+"""
+import math
+
+import pytest
+import torch
+
+from olmo.config import InitFnType, ModelConfig
+from olmo.ultramem_layer_v2 import UltraMemLayerV2
+
+
+def _make_config(n_layers=8, init_fn=InitFnType.full_megatron, init_std=0.02282):
+    cfg = ModelConfig()
+    cfg.n_layers = n_layers
+    cfg.d_model = 512
+    cfg.init_fn = init_fn
+    cfg.init_std = init_std
+    cfg.init_device = "cpu"
+    cfg.mlp_ratio = 8
+    cfg.mem_q_for_each_tucker_rank = True
+    cfg.mem_use_glu_act = False
+    cfg.mem_key_expand_time = 2
+    cfg.mem_output_dropout_rate = 0.0
+    cfg.vertical_parallel = False
+    cfg.mem_parallel_size = 1
+    return cfg
+
+
+def _make_layer(has_value, n_layers=8, init_fn=InitFnType.full_megatron):
+    cfg = _make_config(n_layers=n_layers, init_fn=init_fn)
+    return UltraMemLayerV2(
+        hidden_size=512, knum=64, kdim=128, vdim=144, pre_vdim=48,
+        knn=32, head=1, tucker_rank=2, tucker_multihead=2,
+        value_expand_time=1, tucker_rank_penalty=0.0,
+        layer_id=0, has_value=has_value,
+        share_ratio=1.0, mem_layer_num=n_layers, config=cfg,
+    )
+
+
+def test_sigma_s_squared_is_finite_and_small():
+    """sigma_s^2 should be a finite positive number well under 10 — paper hint
+    puts it near 0.1.  Anything larger means the calibration is mis-scaled and
+    Eq. 26 will produce a meaningless sigma_V."""
+    layer = _make_layer(has_value=False)
+    sigma_s_sq = layer._measure_sigma_s_squared(n_samples=512)
+    assert math.isfinite(sigma_s_sq)
+    assert 0.0 < sigma_s_sq < 10.0, f"sigma_s^2 out of expected range: {sigma_s_sq}"
+
+
+def test_values_proj_std_depth_scales_under_full_megatron():
+    """Paper Eq. 26 derivation assumes ff_out is 1/sqrt(2L)-scaled.  For
+    init_fn=full_megatron, values_proj must follow the same scaling so the
+    memory residual matches the FFN residual at init."""
+    layer = _make_layer(has_value=False, n_layers=20, init_fn=InitFnType.full_megatron)
+    expected = layer.config.init_std / math.sqrt(2.0 * 20)
+    got = layer._compute_values_proj_std()
+    assert abs(got - expected) < 1e-9, (got, expected)
+
+
+def test_values_proj_std_falls_back_under_normal():
+    """For init_fn=normal (no depth scaling), values_proj should match
+    init_std so the memory residual matches the FFN residual."""
+    layer = _make_layer(has_value=False, init_fn=InitFnType.normal)
+    got = layer._compute_values_proj_std()
+    assert abs(got - 0.02282) < 1e-9, got
+
+
+def test_eq26_value_init_runs_and_produces_reasonable_std():
+    """End-to-end: reset_parameters on a has_value=True layer should populate
+    values_for_look_up with finite, non-zero std reasonably close to sigma_V."""
+    layer = _make_layer(has_value=True)
+    layer.reset_parameters(distributed_strategy=None)
+    assert layer.values_for_look_up.isfinite().all()
+    actual_std = layer.values_for_look_up.float().std().item()
+    # sigma_V in this config is tiny — assert it's finite, positive, and < 1.
+    assert 0.0 < actual_std < 1.0, actual_std


### PR DESCRIPTION
This PR adds FSDP (FullyShardedDataParallel) compatibility for UltraMem and ships a handful of paper-accuracy + observability fixes that we found necessary while training UltraMemV2 at scale.

**FSDP support**
- FSDP wrapping for UltraMem layers with correct `main_grad` allocation ordering, `summon_full_params` for paper-faithful init, and `ignored_states` for the unsharded value table (`full_memory_layer` is accessed directly by `mem_blocks`, not through its own `forward()`).
- Unsharded checkpoint save/load for vertical-parallel value tables — managed FSDP params go through the normal `FULL_STATE_DICT` path, ignored (vertical-parallel) params are saved per-rank, with a NaN guard on restore.
- Guard manual `param.grad` all-reduce behind the non-FSDP path so FSDP's reduce-scatter isn't double-counted.
- Activation checkpointing for `mem_blocks` in both the `'full'` and per-block `mem_insert_way` paths.

**Paper-accurate init**
- Implements Eq. 26 (App. A.3) for the value table σ_V, with σ_s² measured empirically via App. A.2.
- Depth-scaled `values_proj` (the residual-stream projection) so the memory-layer output variance at init matches the FFN baseline that Eq. 26 calibrates against.

**fp32 value-table autograd**
- `FusedLookup` / `XperfGlu` now take `weight_bf16` and `main_grad` as explicit inputs. Backward writes gradients into the original `main_grad` storage (verified by a sentinel test) instead of relying on the prior `param_bf16` pattern that lost storage identity after `ctx.saved_tensors` pack/unpack.

**Triton + observability**
- Triton gather kernel (`triton_gather_indices_2d`) replaces an O(knn²) intermediate that OOM'd at knn=256.
- File-based memory-metrics logging block that fires when `wandb=null`, with an `_accumulate_stats` flag gating per-step stats accumulation.

## Tests

- `tests/test_ultramem_init_variance.py` — 4 tests covering Eq. 26 std, `values_proj` depth scaling across init strategies, and σ_s² stability.
- `tests/test_fused_index_autograd.py` — 11 tests covering `FusedLookup` / `XperfGlu` signatures, backward arity, storage identity for `main_grad`, and bf16 vs fp32 weight paths.
- Both files pass on CPU (`pytest tests/test_ultramem_init_variance.py tests/test_fused_index_autograd.py`).

